### PR TITLE
Allow underscore for property name

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,15 @@
     ],
     "parserOptions": {
       "project": "./tsconfig.json"
+    },
+    "rules": {
+      "no-underscore-dangle": [
+        "error",
+        {
+          "allowAfterThis": true,
+          "enforceInMethodNames": true
+        }
+      ]
     }
   },
   "browserslist": {


### PR DESCRIPTION
private setter/public getter を実現したいため、private のメンバ名を `_` 付きを許可するように変更

```ts
class Foo {
  private _foo: string;

  public get foo(): string {
    return this._foo;
  }

  public update(foo: string): void {
    this._foo = foo;
  }

  // ...
}
```