### PR TITLE
Change return type in repositories

### DIFF
--- a/src/domain/models/circle/ICircleRepository.ts
+++ b/src/domain/models/circle/ICircleRepository.ts
@@ -3,8 +3,8 @@ import CircleId from './CircleId';
 import CircleName from './CircleName';
 
 export interface ICircleRepository {
-  find(id: CircleId): Promise<Circle>;
-  find(id: CircleName): Promise<Circle>;
+  find(id: CircleId): Promise<Circle | undefined>;
+  find(id: CircleName): Promise<Circle | undefined>;
   findAll(): Promise<Iterable<Circle>>;
   save(circle: Circle): Promise<void>;
   delete(circle: Circle): Promise<void>;

--- a/src/domain/models/circle/ICircleRepository.ts
+++ b/src/domain/models/circle/ICircleRepository.ts
@@ -4,7 +4,7 @@ import CircleName from './CircleName';
 
 export interface ICircleRepository {
   find(id: CircleId): Promise<Circle | undefined>;
-  find(id: CircleName): Promise<Circle | undefined>;
+  find(name: CircleName): Promise<Circle | undefined>;
   findAll(): Promise<Iterable<Circle>>;
   save(circle: Circle): Promise<void>;
   delete(circle: Circle): Promise<void>;

--- a/src/domain/models/user/IUserRepository.ts
+++ b/src/domain/models/user/IUserRepository.ts
@@ -3,8 +3,8 @@ import UserId from './UserId';
 import UserName from './UserName';
 
 export interface IUserRepository {
-  find(id: UserId): Promise<User>;
-  find(name: UserName): Promise<User>;
+  find(id: UserId): Promise<User | undefined>;
+  find(name: UserName): Promise<User | undefined>;
   find(ids: Iterable<UserId>): Promise<Iterable<User>>;
   findAll(): Promise<Iterable<User>>;
   save(user: User): Promise<void>;


### PR DESCRIPTION
Repository の取得メソッドの返り値は `undefined` があり得るため型の指定を変更

NullObject パターンに変更したほうがいいかも

